### PR TITLE
Add: npm package now works with jsx files

### DIFF
--- a/npm-install.py
+++ b/npm-install.py
@@ -24,7 +24,7 @@ root = {}
 
 
 def is_valid(view):
-    return view.file_name() != None and view.file_name().endswith('.js')
+    return view.file_name() != None and view.file_name().endswith(('.js', '.jsx'))
 
 def exec(args, pn):
     if sys.platform != 'win32':


### PR DESCRIPTION
npm-install only worked on files ending in .js , but now npm-install can work on files also ending in .jsx. This is useful, since some files can end in .jsx when working with ReactJs. 